### PR TITLE
Enhance test coverage

### DIFF
--- a/tests/indexer_test.rs
+++ b/tests/indexer_test.rs
@@ -2,7 +2,10 @@ use std::str::FromStr;
 
 use bitcoin::{absolute::LockTime, transaction::Version, BlockHash, Transaction, Txid};
 use bitcoin_indexer::{
-    bitcoin_client::MockBitcoinClient, indexer::{Indexer, IndexerApi}, store::MockIndexerStore, types::{BlockInfo, FullBlock, TransactionInfo}
+    bitcoin_client::MockBitcoinClient,
+    indexer::{Indexer, IndexerApi},
+    store::MockIndexerStore,
+    types::{BlockInfo, FullBlock, TransactionInfo},
 };
 use mockall::predicate::eq;
 
@@ -178,8 +181,10 @@ fn test_get_best_block() -> Result<(), anyhow::Error> {
     let bitcoin_client = MockBitcoinClient::new();
     let mut store = MockIndexerStore::new();
 
-    let hash = BlockHash::from_str("000000000000000000076c3e2e0f70537b1bf75268e502e0123b35a6207bf7e2")?;
-    let prev_hash = BlockHash::from_str("000000000000000000045bc1e2ff2a08d10e3fae9b0a8b3536acb6f43adf1234")?;
+    let hash =
+        BlockHash::from_str("000000000000000000076c3e2e0f70537b1bf75268e502e0123b35a6207bf7e2")?;
+    let prev_hash =
+        BlockHash::from_str("000000000000000000045bc1e2ff2a08d10e3fae9b0a8b3536acb6f43adf1234")?;
     let full_block = FullBlock {
         height: 1000,
         hash: hash.clone(),
@@ -206,13 +211,16 @@ fn test_get_tx_existing_non_orphan() {
     let mut bitcoin_client = MockBitcoinClient::new();
     let mut store = MockIndexerStore::new();
 
-    let tx_id = Txid::from_str("4d3a5c31e5a25d27687a3ed3bb8a3f65e5fdccf39f476574f8a73d38a65f3a5d").unwrap();
-    let block_hash = BlockHash::from_str("12efaa3528db3845a859c470a525f1b8b4643b0d561f961ab395a9db778c204d").unwrap();
+    let tx_id =
+        Txid::from_str("4d3a5c31e5a25d27687a3ed3bb8a3f65e5fdccf39f476574f8a73d38a65f3a5d").unwrap();
+    let block_hash =
+        BlockHash::from_str("12efaa3528db3845a859c470a525f1b8b4643b0d561f961ab395a9db778c204d")
+            .unwrap();
     let transact = Transaction {
         version: Version::TWO,
         lock_time: LockTime::ZERO,
         input: vec![],
-        output: vec![]
+        output: vec![],
     };
     let tx_info = TransactionInfo {
         tx: transact,
@@ -222,23 +230,30 @@ fn test_get_tx_existing_non_orphan() {
         confirmations: 0,
     };
 
-    store.expect_get_tx_info()
+    store
+        .expect_get_tx_info()
         .with(eq(tx_id.clone()))
         .returning(move |_| Ok(Some(tx_info.clone())));
 
     let best_block = FullBlock {
         height: 505,
-        hash: BlockHash::from_str("12efaa3528db3845a859c470a525f1b8b4643b0d561f961ab395a9db778c204d").unwrap(),
-        prev_hash: BlockHash::from_str("e3d2aa2c8211961e6a6f94740cd1e9be6a8e55534ed824f82a157dd2c51be5f2").unwrap(),
+        hash: BlockHash::from_str(
+            "12efaa3528db3845a859c470a525f1b8b4643b0d561f961ab395a9db778c204d",
+        )
+        .unwrap(),
+        prev_hash: BlockHash::from_str(
+            "e3d2aa2c8211961e6a6f94740cd1e9be6a8e55534ed824f82a157dd2c51be5f2",
+        )
+        .unwrap(),
         orphan: false,
-        txs: vec![]
+        txs: vec![],
     };
 
-    store.expect_get_best_block()
+    store
+        .expect_get_best_block()
         .returning(move || Ok(Some(best_block.clone())));
 
-    bitcoin_client.expect_get_best_block()
-        .returning(|| Ok(505));
+    bitcoin_client.expect_get_best_block().returning(|| Ok(505));
 
     let indexer = Indexer::new(bitcoin_client, store);
 
@@ -253,7 +268,8 @@ fn test_get_tx_existing_orphan() {
     let bitcoin_client = MockBitcoinClient::new();
     let mut store = MockIndexerStore::new();
 
-    let tx_id = Txid::from_str("4d3a5c31e5a25d27687a3ed3bb8a3f65e5fdccf39f476574f8a73d38a65f3a5d").unwrap();
+    let tx_id =
+        Txid::from_str("4d3a5c31e5a25d27687a3ed3bb8a3f65e5fdccf39f476574f8a73d38a65f3a5d").unwrap();
 
     let tx_info = TransactionInfo {
         tx: Transaction {
@@ -263,24 +279,35 @@ fn test_get_tx_existing_orphan() {
             output: vec![],
         },
         block_height: 0,
-        block_hash: BlockHash::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+        block_hash: BlockHash::from_str(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap(),
         orphan: true,
         confirmations: 0,
     };
 
-    store.expect_get_tx_info()
+    store
+        .expect_get_tx_info()
         .with(eq(tx_id.clone()))
         .returning(move |_| Ok(Some(tx_info.clone())));
 
     let best_block = FullBlock {
         height: 1000,
-        hash: BlockHash::from_str("0000000000000000000000000000000000000000000000000000000000000001").unwrap(),
-        prev_hash: BlockHash::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+        hash: BlockHash::from_str(
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        )
+        .unwrap(),
+        prev_hash: BlockHash::from_str(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap(),
         orphan: true,
-        txs: vec![]
+        txs: vec![],
     };
 
-    store.expect_get_best_block()
+    store
+        .expect_get_best_block()
         .returning(move || Ok(Some(best_block.clone())));
 
     let indexer = Indexer::new(bitcoin_client, store);
@@ -289,7 +316,7 @@ fn test_get_tx_existing_orphan() {
     assert!(result.is_some());
 
     let tx_info = result.unwrap();
-    assert_eq!(tx_info.confirmations, 0); 
+    assert_eq!(tx_info.confirmations, 0);
 }
 
 #[test]
@@ -297,9 +324,11 @@ fn test_get_tx_nonexistent() {
     let bitcoin_client = MockBitcoinClient::new();
     let mut store = MockIndexerStore::new();
 
-    let tx_id = Txid::from_str("4d3a5c31e5a25d27687a3ed3bb8a3f65e5fdccf39f476574f8a73d38a65f3a5d").unwrap();
+    let tx_id =
+        Txid::from_str("4d3a5c31e5a25d27687a3ed3bb8a3f65e5fdccf39f476574f8a73d38a65f3a5d").unwrap();
 
-    store.expect_get_tx_info()
+    store
+        .expect_get_tx_info()
         .with(eq(tx_id.clone()))
         .returning(move |_| Ok(None));
 


### PR DESCRIPTION
Adding several test to increase test coverage of this module, here's some more context on the reason to add these tests:

- Block reorganization:
The reorg_1_block test handles cases of chain reorganization, a critical aspect for an indexer. It ensures that the indexer correctly detects and adjusts blocks in response to changes in the blockchain structure.

- Blockchain height lower than index:
Tests like test_blockchain_height_lower_than_index_height and test_blockchain_height_less_than_index_height cover situations where the maximum blockchain height is lower than the index height. This ensures that the indexer does not attempt to process non-existent heights.

- Invalid or missing blocks:
test_index_height_block_not_exists and test_index_height_invalid_block handle situations where blocks are missing or have invalid data. This helps prevent silent errors and ensures that irregularities are detected.

- Empty string:
test_index_height_empty_blockchain checks the behavior of the system when there are no blocks available, which is critical to properly initialize the indexer.

- Height overflow:
test_index_height_upper_limit_reached tests the case of reaching an upper limit on the height, simulating a scenario where the blockchain reaches an unsupported height.

- Getting the best block:
test_get_best_block validates the correct interaction with the Bitcoin client API and store to retrieve information about the highest block.

With this info, there are some tests that are failing when being executed, not sure if it's due to a bug or an error on the test design/implementation:

---- test_index_height_empty_blockchain stdout ----
thread 'test_index_height_empty_blockchain' panicked at tests\indexer_test.rs:324:5:
Error expected while trying to index in an empty blockchain

---- test_index_height_invalid_block stdout ----
thread 'test_index_height_invalid_block' panicked at tests\indexer_test.rs:437:5:
Expected error while processing an invalid block

Please review and accept or suggest changes to this suite of tests.