### PR TITLE
fix: advance cursor from an unset best height (genesis edge case)

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -95,11 +95,13 @@ impl StoreClient for IndexerStore {
                 }
                 // Advance the cursor only when this block is ahead of it, so
                 // tick() does not loop forever re-saving the same already-stored
-                // block. Never move it backward: save_new_best_block can be
-                // called with an older block (for example re-checking a lower
-                // height), and lowering the best height would corrupt the cursor.
-                let current_best = self.get_best_height()?.unwrap_or(0);
-                if block.height > current_best {
+                // block. Compare the Option directly: this also advances from an
+                // unset cursor (None < Some(h)), including the genesis block at
+                // height 0, which unwrap_or(0) would miss since 0 > 0 is false.
+                // It never lowers the cursor, because save_new_best_block can be
+                // called with an older block and regressing the height would
+                // corrupt the cursor.
+                if self.get_best_height()? < Some(block.height) {
                     self.save_best_height(block.height)?;
                 }
                 return Ok(());

--- a/tests/cursor_stuck_regression_test.rs
+++ b/tests/cursor_stuck_regression_test.rs
@@ -64,6 +64,8 @@ const NEXT_BLOCK_HEIGHT: BlockHeight = 4_977_629;
 const PREV_HASH: &str = "0000000000000000000a1e2b6f1f3b7f0a1f1e2b6f1f3b7f0a1f1e2b6f1f3b7f";
 const PREV_BLOCK_HASH: &str = "0000000000000000000b1e2b6f1f3b7f0b1f1e2b6f1f3b7f0b1f1e2b6f1f3b7f";
 const NEXT_BLOCK_HASH: &str = "0000000000000000000c1e2b6f1f3b7f0c1f1e2b6f1f3b7f0c1f1e2b6f1f3b7f";
+const GENESIS_HASH: &str = "0000000000000000000d1e2b6f1f3b7f0d1f1e2b6f1f3b7f0d1f1e2b6f1f3b7f";
+const ZERO_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
 
 fn block(height: BlockHeight, hash: &str, prev_hash: &str) -> BlockInfo {
     BlockInfo {
@@ -167,5 +169,59 @@ fn cursor_stuck_after_crash_during_save() -> Result<(), anyhow::Error> {
     }
 
     clear_output();
+    Ok(())
+}
+
+/// Edge case: the genesis block (height 0) is already stored but the cursor is
+/// unset (None), which can happen if a crash interrupts the very first save
+/// between the block write and the cursor write. Re-saving it must advance the
+/// cursor to 0. Comparing best height as `unwrap_or(0)` missed this, because
+/// 0 > 0 is false; comparing the Option directly (None < Some(0)) handles it.
+#[test]
+fn cursor_advances_from_unset_for_genesis_block() -> Result<(), anyhow::Error> {
+    use bitcoin_indexer::store::IndexerStore;
+    use std::rc::Rc;
+    use storage_backend::storage::{KeyValueStore, Storage};
+    use storage_backend::storage_config::StorageConfig;
+
+    // Use a private temp dir so this test never disturbs the shared test_output
+    // directory used by the other tests in this binary.
+    let dir = std::env::temp_dir().join(format!(
+        "indexer_genesis_cursor_{}",
+        crate::utils::generate_random_string()
+    ));
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.to_string_lossy().replace('\\', "/");
+
+    let storage = Rc::new(Storage::new(&StorageConfig::new(path, None))?);
+    let store = IndexerStore::new(storage.clone())?;
+
+    let genesis = block(0, GENESIS_HASH, ZERO_HASH);
+
+    // Store genesis normally; the full save path also sets the cursor to 0.
+    store.save_new_best_block(&genesis, 0)?;
+
+    // Simulate a crash that wrote the block but not the cursor: clear the
+    // best-height key directly. This key mirrors StoreKey::BestBlock in store.rs.
+    storage.remove("indexer/meta/best_block_height", None)?;
+    assert_eq!(
+        store.get_best_height()?,
+        None,
+        "setup: genesis stored but the best-height cursor is unset"
+    );
+
+    // Re-saving the already-stored genesis hits the early-return branch, which
+    // must set the cursor to 0 even though it is currently None.
+    store.save_new_best_block(&genesis, 0)?;
+    assert_eq!(
+        store.get_best_height()?,
+        Some(0),
+        "an unset cursor must advance to the stored genesis height 0; unwrap_or(0) \
+         would leave it unset because 0 > 0 is false"
+    );
+
+    drop(store);
+    drop(storage);
+    let _ = std::fs::remove_dir_all(&dir);
     Ok(())
 }


### PR DESCRIPTION
The cursor-advance check in save_new_best_block used unwrap_or(0), which treats None and Some(0) alike, so a stored genesis block at height 0 with an unset cursor never advanced (0 > 0 is false). Compare the Option directly (None < Some(h)) so an unset cursor advances, including at height 0, without ever lowering the cursor.

Add a regression test: genesis stored with the cursor cleared must advance to 0.